### PR TITLE
Remove trash Ravens from the checker

### DIFF
--- a/.github/workflows/check-nfl-games.yml
+++ b/.github/workflows/check-nfl-games.yml
@@ -32,15 +32,6 @@ jobs:
           reg-season-start: "09-01"
           sport-name: "NFL"
 
-      - name: Check for Ravens games
-        uses: ./.github/actions/check-sports-games
-        with:
-          sport: "2"
-          teams: "bal"
-          off-season-start: "02-15"
-          reg-season-start: "09-01"
-          sport-name: "NFL"
-
       - name: Check for Eagles games
         uses: ./.github/actions/check-sports-games
         with:


### PR DESCRIPTION
### Description
NBA season is back, babyyy!! But the point of this PR is to remove the trash Ravens from the scheduler. I don't care to see when they play anymore this season. Lamar is out for the season and even when he was in, the defense looked like I was out there playing.